### PR TITLE
Add `arrowParensAlways` to options

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,10 @@ var defaults = {
   trailingComma: false,
 
   // Controls the printing of spaces inside array and objects
-  bracketSpacing: true
+  bracketSpacing: true,
+  
+  // If true will allways wraps arrow functions params in parens - even if just 1 param
+  arrowParensAlways: false,
 };
 
 // Copy options and fill in default values.


### PR DESCRIPTION
`arrowParensAlways` is being used however is not listed in the options.

I've been looking over the tests, however couldn't pinpoint any required changes. Will pull the repo locally.